### PR TITLE
Add sentry.io for openai

### DIFF
--- a/chatgpt.list
+++ b/chatgpt.list
@@ -16,3 +16,5 @@ DOMAIN-SUFFIX,stripe.com
 DOMAIN-SUFFIX,poe.com
 #add bard.google.com
 DOMAIN-SUFFIX,bard.google.com
+#add sentry.io
+DOMAIN-SUFFIX,sentry.io


### PR DESCRIPTION
I found that openai will send a request to sentry.io, so I add the domain into openai